### PR TITLE
Enforce strict multi-tenant validation on S3 storage hooks

### DIFF
--- a/services/gateway/src/adapters/inbound/graphql/schema.rs
+++ b/services/gateway/src/adapters/inbound/graphql/schema.rs
@@ -726,7 +726,8 @@ impl Mutation {
             .finalize_object(
                 &staging_key,
                 &upload_meta.s3_key,
-                Some(&ctx.tenant_id),
+                &ctx.tenant_id,
+                &ctx.user_id,
                 tagging_query.as_deref(),
             )
             .await

--- a/services/gateway/src/adapters/inbound/graphql/schema.rs
+++ b/services/gateway/src/adapters/inbound/graphql/schema.rs
@@ -641,12 +641,14 @@ impl Mutation {
         target_name: String,
         permissions_json: Option<String>,
     ) -> FieldResult<String> {
+        fn graphql_error<E: std::fmt::Display>(err: E) -> juniper::FieldError {
+            juniper::FieldError::new(err.to_string(), juniper::Value::Null)
+        }
+
         ctx.identity
             .verify_user(&ctx.tenant_id, &ctx.user_id)
             .await
-            .map_err(|e| {
-                juniper::FieldError::new(e.to_string(), juniper::Value::Null)
-            })?;
+            .map_err(graphql_error)?;
 
         let authorized = ctx
             .auth_service
@@ -658,84 +660,79 @@ impl Mutation {
                 None,
             )
             .await
-            .map_err(|e| {
-                juniper::FieldError::new(e.to_string(), juniper::Value::Null)
-            })?;
+            .map_err(graphql_error)?;
 
         if !authorized {
-            return Err(juniper::FieldError::new(
+            return Err(graphql_error(
                 "Unauthorized write operation on tenant",
-                juniper::Value::Null,
             ));
         }
 
-        let mut viewers_csv: Option<String> = None;
-        if let Some(json_str) = permissions_json
+        let viewers_csv = match permissions_json
             .as_deref()
             .map(str::trim)
-            .filter(|s| !s.is_empty())
+            .filter(|json| !json.is_empty())
         {
-            let requested_perms: Vec<
-                crate::domain::permission::IamPermission,
-            > = serde_json::from_str(json_str).map_err(|e| {
-                juniper::FieldError::new(
-                    format!("Invalid permissions JSON structure: {}", e),
-                    juniper::Value::Null,
-                )
-            })?;
+            Some(json) => {
+                let requested_permissions: Vec<
+                    crate::domain::permission::IamPermission,
+                > = serde_json::from_str(json).map_err(|e| {
+                    graphql_error(format!(
+                        "Invalid permissions JSON structure: {e}"
+                    ))
+                })?;
 
-            if !requested_perms.is_empty() {
-                let current_perms = ctx
-                    .iam_store
-                    .get_effective_permissions_for_user(
-                        &ctx.tenant_id,
-                        &ctx.user_id,
-                    )
-                    .await
-                    .map_err(|e| {
-                        juniper::FieldError::new(
-                            e.to_string(),
-                            juniper::Value::Null,
+                if requested_permissions.is_empty() {
+                    None
+                } else {
+                    let current_permissions = ctx
+                        .iam_store
+                        .get_effective_permissions_for_user(
+                            &ctx.tenant_id,
+                            &ctx.user_id,
                         )
-                    })?;
+                        .await
+                        .map_err(graphql_error)?;
 
-                if !crate::application::usecases::iam_scope::can_grant_all(
-                    &current_perms,
-                    &requested_perms,
-                ) {
-                    return Err(juniper::FieldError::new(
-                        "Requested access envelope exceeds user's current authorization bounds",
-                        juniper::Value::Null,
-                    ));
+                    if !crate::application::usecases::iam_scope::can_grant_all(
+                        &current_permissions,
+                        &requested_permissions,
+                    ) {
+                        return Err(graphql_error(
+                            "Requested access envelope exceeds user's current authorization bounds",
+                        ));
+                    }
+
+                    viewers_from_permissions(&requested_permissions)
                 }
-
-                viewers_csv = viewers_from_permissions(&requested_perms);
-            }
-        }
+            },
+            None => None,
+        };
 
         let upload_meta =
             sanitize_upload_request(&ctx.tenant_id, None, &target_name)
                 .map_err(|e| {
-                    juniper::FieldError::new(
-                        format!("Invalid upload parameters: {}", e),
-                        juniper::Value::Null,
-                    )
+                    graphql_error(format!("Invalid upload parameters: {e}"))
                 })?;
-        let dest_key = upload_meta.s3_key;
+
         let tagging_query = build_tagging_query(
             &ctx.tenant_id,
             &ctx.user_id,
             viewers_csv.as_deref(),
         );
 
-        ctx.s3
-            .finalize_object(&staging_key, &dest_key, tagging_query.as_deref())
+        let destination_key = ctx
+            .s3
+            .finalize_object(
+                &staging_key,
+                &upload_meta.s3_key,
+                Some(&ctx.tenant_id),
+                tagging_query.as_deref(),
+            )
             .await
-            .map_err(|e| {
-                juniper::FieldError::new(e.to_string(), juniper::Value::Null)
-            })?;
+            .map_err(graphql_error)?;
 
-        Ok(dest_key)
+        Ok(destination_key)
     }
 }
 

--- a/services/gateway/src/adapters/outbound/storage/s3.rs
+++ b/services/gateway/src/adapters/outbound/storage/s3.rs
@@ -81,28 +81,51 @@ impl S3Uploader {
             .to_string())
     }
 
+    /// Validates that a staging object key belongs to the provided tenant
+    /// and authenticated user.
+    fn validate_staging_key(
+        key: &str,
+        tenant: &str,
+        user: &str,
+    ) -> Result<()> {
+        let key = key.trim().trim_start_matches('/');
+
+        let mut parts = key.split('/');
+
+        let key_tenant = parts.next();
+        let key_user = parts.next();
+
+        match (key_tenant, key_user) {
+            (Some(actual_tenant), Some(actual_user))
+                if actual_tenant.eq_ignore_ascii_case(tenant) &&
+                    actual_user == user =>
+            {
+                Ok(())
+            },
+            _ => {
+                bail!(
+                    "Staging object does not belong to authenticated tenant/user"
+                )
+            },
+        }
+    }
+
     /// Resolves destination key and validates tenant isolation rules.
     fn resolve_destination_key(
         dest_key: &str,
-        tenant: Option<&str>,
+        tenant: &str,
     ) -> Result<String> {
         let key = dest_key.trim().trim_start_matches('/');
         let path_tenant = key.split_once('/').map(|(tenant, _)| tenant);
-        let tenant = tenant.map(str::trim).filter(|value| !value.is_empty());
 
-        match (tenant, path_tenant) {
-            (Some(expected), Some(actual))
-                if !expected.eq_ignore_ascii_case(actual) =>
-            {
+        match path_tenant {
+            Some(actual) if !tenant.eq_ignore_ascii_case(actual) => {
                 bail!(
-                    "Tenant mismatch in finalize operation. Context claims {expected:?}, but target path requests {actual:?}",
+                    "Tenant mismatch in finalize operation. Context claims {tenant:?}, but target path requests {actual:?}",
                 );
             },
-            (Some(_), Some(_)) | (None, Some(_)) => Ok(key.to_owned()),
-            (Some(tenant), None) => Ok(format!("{tenant}/{key}")),
-            (None, None) => {
-                bail!("Object cannot be moved without a tenant context.");
-            },
+            Some(_) => Ok(key.to_owned()),
+            None => Ok(format!("{tenant}/{key}")),
         }
     }
 
@@ -160,14 +183,16 @@ impl S3Uploader {
         &self,
         staging_key: &str,
         dest_key: &str,
-        tenant: Option<&str>,
+        tenant: &str,
+        user: &str,
         tagging_query: Option<&str>,
     ) -> Result<String> {
+        Self::validate_staging_key(staging_key, tenant, user)?;
+
         let destination_key = Self::resolve_destination_key(dest_key, tenant)?;
 
         self.copy_to_destination(staging_key, &destination_key, tagging_query)
             .await?;
-
         self.delete_staging_object(staging_key).await?;
 
         Ok(destination_key)

--- a/services/gateway/src/adapters/outbound/storage/s3.rs
+++ b/services/gateway/src/adapters/outbound/storage/s3.rs
@@ -2,11 +2,12 @@
 
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use aws_config::Region;
 use aws_sdk_s3::Client;
 use aws_sdk_s3::config::Credentials;
 use aws_sdk_s3::presigning::PresigningConfig;
+use aws_sdk_s3::types::TaggingDirective;
 
 pub struct S3Uploader {
     client: Client,
@@ -26,44 +27,40 @@ impl S3Uploader {
     ) -> Result<Self> {
         let config = aws_config::from_env()
             .endpoint_url(endpoint)
-            .region(Region::new(region.to_string()))
+            .region(Region::new(region.to_owned()))
             .load()
             .await;
 
         let credentials =
             Credentials::new(access_key, secret_key, None, None, "static");
 
-        let s3_config = aws_sdk_s3::config::Builder::from(&config)
-            .credentials_provider(credentials)
-            .force_path_style(true)
-            .build();
-
-        let client = Client::from_conf(s3_config);
+        let client = Client::from_conf(
+            aws_sdk_s3::config::Builder::from(&config)
+                .credentials_provider(credentials)
+                .force_path_style(true)
+                .build(),
+        );
 
         // Verify reachability of both critical storage buckets.
-        client
-            .head_bucket()
-            .bucket(staging_bucket)
-            .send()
-            .await
-            .context(format!(
-                "Staging bucket {staging_bucket:?} not reachable"
-            ))?;
-
-        client
-            .head_bucket()
-            .bucket(destination_bucket)
-            .send()
-            .await
-            .context(format!(
-                "Destination bucket {destination_bucket:?} not reachable"
-            ))?;
+        Self::verify_bucket(&client, staging_bucket).await?;
+        Self::verify_bucket(&client, destination_bucket).await?;
 
         Ok(Self {
             client,
-            staging_bucket: staging_bucket.to_string(),
-            destination_bucket: destination_bucket.to_string(),
+            staging_bucket: staging_bucket.to_owned(),
+            destination_bucket: destination_bucket.to_owned(),
         })
+    }
+
+    async fn verify_bucket(client: &Client, bucket: &str) -> Result<()> {
+        client
+            .head_bucket()
+            .bucket(bucket)
+            .send()
+            .await
+            .with_context(|| format!("Bucket {bucket:?} is not reachable"))?;
+
+        Ok(())
     }
 
     /// Generates a temporary presigned PUT URL targeting the staging bucket.
@@ -72,45 +69,77 @@ impl S3Uploader {
         key: &str,
         expires_in: Duration,
     ) -> Result<String> {
-        let presigned_req = self
+        Ok(self
             .client
             .put_object()
             .bucket(&self.staging_bucket)
             .key(key)
             .presigned(PresigningConfig::expires_in(expires_in)?)
             .await
-            .context("Failed to generate presigned PUT URL")?;
-
-        Ok(presigned_req.uri().to_string())
+            .context("Failed to generate presigned PUT URL")?
+            .uri()
+            .to_string())
     }
 
-    /// Atomically copies object to destination bucket with new tags, then
-    /// purges staging source.
-    pub async fn finalize_object(
+    /// Resolves destination key and validates tenant isolation rules.
+    fn resolve_destination_key(
+        dest_key: &str,
+        tenant: Option<&str>,
+    ) -> Result<String> {
+        let key = dest_key.trim().trim_start_matches('/');
+        let path_tenant = key.split_once('/').map(|(tenant, _)| tenant);
+        let tenant = tenant.map(str::trim).filter(|value| !value.is_empty());
+
+        match (tenant, path_tenant) {
+            (Some(expected), Some(actual))
+                if !expected.eq_ignore_ascii_case(actual) =>
+            {
+                bail!(
+                    "Tenant mismatch in finalize operation. Context claims {expected:?}, but target path requests {actual:?}",
+                );
+            },
+            (Some(_), Some(_)) | (None, Some(_)) => Ok(key.to_owned()),
+            (Some(tenant), None) => Ok(format!("{tenant}/{key}")),
+            (None, None) => {
+                bail!("Object cannot be moved without a tenant context.");
+            },
+        }
+    }
+
+    async fn copy_to_destination(
         &self,
         staging_key: &str,
-        dest_key: &str,
+        destination_key: &str,
         tagging_query: Option<&str>,
     ) -> Result<()> {
         let source = format!("{}/{}", self.staging_bucket, staging_key);
-        let mut copy_req = self
+
+        let mut request = self
             .client
             .copy_object()
             .bucket(&self.destination_bucket)
-            .key(dest_key)
+            .key(destination_key)
             .copy_source(source);
 
-        if let Some(tags) = tagging_query.filter(|s| !s.trim().is_empty()) {
-            copy_req = copy_req.tagging(tags);
-            copy_req = copy_req.tagging_directive(
-                aws_sdk_s3::types::TaggingDirective::Replace,
-            );
+        if let Some(tags) =
+            tagging_query.map(str::trim).filter(|tags| !tags.is_empty())
+        {
+            request = request
+                .tagging(tags)
+                .tagging_directive(TaggingDirective::Replace);
         }
 
-        copy_req.send().await.context(
-            "Failed to copy object from staging to destination bucket",
-        )?;
+        request.send().await.with_context(|| {
+            format!(
+                "Failed to copy object from staging to destination path {:?}",
+                destination_key,
+            )
+        })?;
 
+        Ok(())
+    }
+
+    async fn delete_staging_object(&self, staging_key: &str) -> Result<()> {
         self.client
             .delete_object()
             .bucket(&self.staging_bucket)
@@ -122,5 +151,25 @@ impl S3Uploader {
             )?;
 
         Ok(())
+    }
+
+    /// Atomically copies object to destination bucket with new tags, then
+    /// purges staging source. Validates tenant multi-tenancy rules before
+    /// execution.
+    pub async fn finalize_object(
+        &self,
+        staging_key: &str,
+        dest_key: &str,
+        tenant: Option<&str>,
+        tagging_query: Option<&str>,
+    ) -> Result<String> {
+        let destination_key = Self::resolve_destination_key(dest_key, tenant)?;
+
+        self.copy_to_destination(staging_key, &destination_key, tagging_query)
+            .await?;
+
+        self.delete_staging_object(staging_key).await?;
+
+        Ok(destination_key)
     }
 }

--- a/services/intake/src/adapters/spi/storage/s3.rs
+++ b/services/intake/src/adapters/spi/storage/s3.rs
@@ -112,6 +112,38 @@ impl S3Adapter {
 
         Ok(parts.join("&"))
     }
+
+    fn resolve_tenant_and_key(
+        key: &str,
+        authz: &AuthzHints,
+    ) -> Result<(String, String)> {
+        let key = key.trim().trim_start_matches('/');
+        let path_tenant = key.split_once('/').map(|(tenant, _)| tenant);
+        let header_tenant = authz
+            .tenant
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        match (header_tenant, path_tenant) {
+            (Some(header), Some(path))
+                if !header.eq_ignore_ascii_case(path) =>
+            {
+                bail!("Tenant mismatch: header {header:?}, path {path:?}");
+            },
+            (Some(header), Some(_)) => Ok((header.to_owned(), key.to_owned())),
+
+            (Some(header), None) => {
+                Ok((header.to_owned(), format!("{header}/{key}")))
+            },
+            (None, Some(path)) => Ok((path.to_owned(), key.to_owned())),
+            (None, None) => {
+                bail!(
+                    "No tenant provided in authorization header or storage key"
+                );
+            },
+        }
+    }
 }
 
 #[async_trait]
@@ -140,38 +172,42 @@ impl BlobStorage for S3Adapter {
         data: &[u8],
         authz: &AuthzHints,
     ) -> Result<String> {
-        let body = ByteStream::from(data.to_vec());
-        let mut put = self
+        let (tenant, key) = Self::resolve_tenant_and_key(key, authz)?;
+
+        let mut authz = authz.clone();
+        authz.tenant = Some(tenant.clone());
+
+        let mut request = self
             .client
             .put_object()
             .bucket(&self.bucket)
-            .key(key)
-            .body(body);
+            .key(&key)
+            .body(ByteStream::from(data.to_vec()))
+            .metadata(META_TENANT, &tenant);
 
-        if let Some(t) = authz.tenant.as_deref() &&
-            !t.trim().is_empty()
+        if let Some(owner) = authz
+            .owner
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
         {
-            put = put.metadata(META_TENANT, t.trim());
-        }
-        if let Some(o) = authz.owner.as_deref() &&
-            !o.trim().is_empty()
-        {
-            put = put.metadata(META_OWNER, o.trim());
-        }
-        if let Some(vcsv) = authz.viewers_csv() {
-            put = put.metadata(META_VIEWER, vcsv);
+            request = request.metadata(META_OWNER, owner);
         }
 
-        let tagging = Self::s3_tagging_query(authz)?;
+        if let Some(viewers) = authz.viewers_csv() {
+            request = request.metadata(META_VIEWER, viewers);
+        }
+
+        let tagging = Self::s3_tagging_query(&authz)?;
         if !tagging.is_empty() {
-            put = put.tagging(tagging);
+            request = request.tagging(tagging);
         }
 
-        put.send()
-            .await
-            .context(format!("Failed to upload (with authz) {key:?}"))?;
+        request.send().await.with_context(|| {
+            format!("Failed to upload validated object {:?}", key)
+        })?;
 
-        Ok(format!("s3://{}/{key}", self.bucket))
+        Ok(format!("s3://{}/{}", self.bucket, key))
     }
 
     async fn download_file(&self, key: &str) -> Result<Vec<u8>> {

--- a/services/intake/src/domain/upload_key.rs
+++ b/services/intake/src/domain/upload_key.rs
@@ -33,7 +33,6 @@ pub fn sanitize_upload_request(
         true,
     )?;
     let object_name = sanitize_component(name, MAX_NAME_LEN, false)?;
-
     let s3_key = format!("{tenant_id}/{group_id}/{object_name}");
 
     Ok(SanitizedUpload {


### PR DESCRIPTION
Closes #29 

- Implement defensive tenant mismatch checks in S3Adapter::upload_file_with_authz
- Update S3Uploader::finalize_object to reject tenant impersonation on staging promotion
- Connect GraphQL complete_upload resolver to pass the authenticated tenant context
- Prevent data leaks and orphans by throwing explicit violations on identity mismatch